### PR TITLE
urls in templates replaced with uri_for equivalents.

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -70,7 +70,7 @@
                         <li class="dropdown">
                             <a href="#" class="dropdown-toggle" data-toggle="dropdown">@{{ username }} <b class="caret"></b></a>
                             <ul class="dropdown-menu">
-                                <li><a href="/settings/profile">{{ lang.menu_edit_profile|safe }}</a></li>
+                                <li><a href="{{ uri_for("edit-profile") }}">{{ lang.menu_edit_profile|safe }}</a></li>
                                 <li class="divider"></li>
                                 <li><a href="{{ logout_url }}">{{ lang.menu_logout|safe }}</a></li>
                             </ul>
@@ -94,12 +94,12 @@
                 {% endblock %}
                 <div class="subnav">
                     <ul class="nav nav-pills">
-                        <li{% if path == "/bootstrap/" %} class="active"{% endif %}><a href="/bootstrap/">Bootstrap</a></li>
-                        <li{% if path == "/contact/" %} class="active"{% endif %}><a href="/contact/">{{ lang.menu_contact|safe }}</a></li>
-                        <li{% if path == "/secure/" %} class="active"{% endif %}><a href="/secure/">{{ lang.menu_secure|safe }}</a></li>
+                        <li{% if path == uri_for("bootstrap") %} class="active"{% endif %}><a href="{{ uri_for("bootstrap") }}">Bootstrap</a></li>
+                        <li{% if path == uri_for("contact") %} class="active"{% endif %}><a href="{{ uri_for("contact") }}">{{ lang.menu_contact|safe }}</a></li>
+                        <li{% if path == uri_for("secure") %} class="active"{% endif %}><a href="{{ uri_for("secure") }}">{{ lang.menu_secure|safe }}</a></li>
                         {% if not user_id %}
-                        <li{% if path == "/register/" %} class="active"{% endif %}><a href="/register/">{{ lang.menu_register|safe }}</a></li>
-                        <li{% if path == "/password-reset/" %} class="active"{% endif %}><a href="/password-reset/">{{ lang.menu_fyp|safe }}</a></li>
+                        <li{% if path == uri_for("register") %} class="active"{% endif %}><a href="{{ uri_for("register") }}">{{ lang.menu_register|safe }}</a></li>
+                        <li{% if path == uri_for("password-reset") %} class="active"{% endif %}><a href="{{ uri_for("password-reset") }}">{{ lang.menu_fyp|safe }}</a></li>
                         {% endif %}
                     </ul>
                 </div>

--- a/templates/boilerplate_edit_profile.html
+++ b/templates/boilerplate_edit_profile.html
@@ -293,7 +293,7 @@
             </div>
             <div class="control-group">
                 <div class="controls">
-                    <a href="/settings/password">{{ lang.menu_edit_password|safe }}</a>
+                    <a href="{{ uri_for("edit-password") }}">{{ lang.menu_edit_password|safe }}</a>
                 </div>
             </div>
             <div class="form-actions">

--- a/templates/boilerplate_home.html
+++ b/templates/boilerplate_home.html
@@ -27,7 +27,7 @@
         </div>
         <div class="span4">
             <h3>Login</h3>
-            <form id="form_login_user" action="/login/" method="post" class="">
+            <form id="form_login_user" action="{{ uri_for("login") }}" method="post" class="">
                 <fieldset class="well">
                     <div class="control-group">
                         <div class="controls">
@@ -42,7 +42,7 @@
                             <label class="checkbox">
                                 <input type="checkbox" name="remember_me" id="remember_me" value="on">
                                 {{ lang.login_remember|safe }}
-                                <a href="/password-reset/">{{ lang.menu_fyp|safe }}</a>
+                                <a href="{{ uri_for("password-reset") }}">{{ lang.menu_fyp|safe }}</a>
                             </label>
                         </div>
                     </div>
@@ -53,7 +53,7 @@
             </form>
 
             <h3>{{ lang.menu_register|safe }}</h3>
-            <form id="form_register" action="/register/" method="post">
+            <form id="form_register" action="{{ uri_for("register") }}" method="post">
                 <fieldset class="well">
                 <div class="control-group">
                     <div class="controls">


### PR DESCRIPTION
 This convention should be used going forward if possible.  This best practice ensures
that changing route url structure will no longer break templates or
require template refactoring
