### PR TITLE
Exclude yaml files from skip_files.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -8,10 +8,6 @@ threadsafe: true
 default_expiration: "30d"
 
 skip_files:
-- ^(.*/)?app\.yaml
-- ^(.*/)?app\.yml
-- ^(.*/)?index\.yaml
-- ^(.*/)?index\.yml
 - ^(.*/)?#.*#
 - ^(.*/)?.*~
 - ^(.*/)?.*\.py[co]


### PR DESCRIPTION
google.appengine.api.appinfo.DEFAULT_SKIP_FILES don't include yaml files.
