### PR TITLE
catch errors related parsing user agent 

### DIFF
--- a/web/handlers.py
+++ b/web/handlers.py
@@ -822,6 +822,13 @@ class ContactHandler(BaseHandler):
         message = self.form.message.data.strip()
 
         try:
+            browser = str(httpagentparser.detect(user_agent)['browser']['name'])
+            browser_version  =  str(httpagentparser.detect(user_agent)['browser']['version'])
+            operating_system = str(httpagentparser.detect(user_agent)['flavor']['name']) + " " + str(httpagentparser.detect(user_agent)['flavor']['version'])
+        except Exception as e:
+            logging.error("error getting user agent info: %s" % e)
+
+        try:
             subject = _("Contact")
             # exceptions for error pages that redirect to contact
             if exception != "":
@@ -830,10 +837,9 @@ class ContactHandler(BaseHandler):
             template_val = {
                 "name": name,
                 "email": email,
-                "browser": str(httpagentparser.detect(user_agent)['browser']['name']),
-                "browser_version": str(httpagentparser.detect(user_agent)['browser']['version']),
-                "operating_system": str(httpagentparser.detect(user_agent)['flavor']['name']) + " " +
-                                    str(httpagentparser.detect(user_agent)['flavor']['version']),
+                "browser": browser,
+                "browser_version": browser_version,
+                "operating_system": operating_system,
                 "ip": remoteip,
                 "message": message
             }


### PR DESCRIPTION
I tried this with my Android phone and it threw 500 errors in the code.  I fixed it so that it won't throw errors.  As more devices use this app it is bound to have other parsing errors.  Because these errors are minor I think they should just be caught and not prevent the user from submitting the contact form.
