### PR TITLE
Removed activaed=True upon user registration, it's already the default value in the User Model

### DIFF
--- a/web/handlers.py
+++ b/web/handlers.py
@@ -615,7 +615,7 @@ class RegisterHandler(RegisterBaseHandler):
         user = self.auth.store.user_model.create_user(
             auth_id, unique_properties, password_raw=password,
             username=username, name=name, last_name=last_name, email=email,
-            ip=self.request.remote_addr, country=country, activated=False
+            ip=self.request.remote_addr, country=country
         )
 
         if not user[0]: #user is a tuple


### PR DESCRIPTION
There shouldn't be a hard value set for activated as there is a default defined by the model.

This causes some unexpected behaviours under some particular circumstances (like changing the Model default value).
