### PR TITLE
Fix link to readme.md

### DIFF
--- a/templates/boilerplate_home.html
+++ b/templates/boilerplate_home.html
@@ -11,7 +11,7 @@
         </h1>
         <p>
             {% trans %}Congratulations on your Google App Engine Boilerplate powered page.{% endtrans %}
-            <br><a href="http://github.com/coto/gae-boilerplate/blob/master/README.rdoc" target="_blank">
+            <br><a href="http://github.com/coto/gae-boilerplate/blob/master/README.md" target="_blank">
             {% trans %}Learn why this Boilerplate Rocks{% endtrans %}</a> {% trans %}or just{% endtrans %} 
             <a href="http://github.com/coto/gae-boilerplate/" target="_blank">{% trans %}download the Source Code{% endtrans %}</a> 
             {% trans %}to help you to create your application.{% endtrans %}


### PR DESCRIPTION
With bb28b7b `README.rdoc` was renamed to `README.md`
