### PR TITLE
Added AES Encryption to the hashing functions in utils

### DIFF
--- a/config.py
+++ b/config.py
@@ -28,6 +28,8 @@ locales = ['en_US', 'es_ES', 'it_IT', 'zh_CN', 'id_ID', 'fr_FR', 'de_DE']
 contact_sender = "PUT_SENDER_EMAIL_HERE"
 contact_recipient = "PUT_RECIPIENT_EMAIL_HERE"
 
+# Password AES Encryption Parameters
+aes_key = "12_24_32_BYTES_KEY_FOR_PASSWORDS"
 salt = "_PUT_SALT_HERE_TO_SHA512_PASSWORDS_"
 
 # get your own consumer key and consumer secret by registering at https://dev.twitter.com/apps


### PR DESCRIPTION
Simple AES Encryption added at the end of the hashing utils as an extra security layer to passwords. This new feature needs to set a 12, 24 or 32 bytes key at the config file. 

The initialization vector can not be randomly generated as usual because is difficult to retrieve them later if we do not know which password we are trying to match. Given that I'm using the same password+salt hash generate the vector making it at least different for each plaintext.
