### PR TITLE
config updated to use webapp2 config dict

### DIFF
--- a/boilerplate/config.py
+++ b/boilerplate/config.py
@@ -1,21 +1,22 @@
-app_name = "Google App Engine Boilerplate"
+config = {
 
-webapp2_config = {}
-webapp2_config['webapp2_extras.sessions'] = {
-    'secret_key': '_PUT_KEY_HERE_YOUR_SECRET_KEY_',
-}
-webapp2_config['webapp2_extras.auth'] = {
-    'user_model': 'boilerplate.models.User',
-    'cookie_name': 'session_name'
-}
-webapp2_config['webapp2_extras.jinja2'] = {
-    'template_path': ['templates','boilerplate/templates'],
-    'environment_args': {'extensions': ['jinja2.ext.i18n']},
-}
+# webapp2 sessions
+'webapp2_extras.sessions' : {'secret_key': '_PUT_KEY_HERE_YOUR_SECRET_KEY_'},
+
+# webapp2 authentication
+'webapp2_extras.auth' : {'user_model': 'boilerplate.models.User',
+                         'cookie_name': 'session_name'},
+
+# jinja2 templates
+'webapp2_extras.jinja2' : {'template_path': ['templates','boilerplate/templates'],
+                           'environment_args': {'extensions': ['jinja2.ext.i18n']}},
+
+# application name
+'app_name' : "Google App Engine Boilerplate",
 
 # the default language code for the application.
 # should match whatever language the site uses when i18n is disabled
-app_lang = 'en'
+'app_lang' : 'en',
 
 # Locale code = <language>_<territory> (ie 'en_US')
 # to pick locale codes see http://cldr.unicode.org/index/cldr-spec/picking-the-right-language-code
@@ -23,64 +24,69 @@ app_lang = 'en'
 # Language codes defined under iso 639-1 http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
 # Territory codes defined under iso 3166-1 alpha-2 http://en.wikipedia.org/wiki/ISO_3166-1
 # disable i18n if locales array is empty or None
-locales = ['en_US', 'es_ES', 'it_IT', 'zh_CN', 'id_ID', 'fr_FR', 'de_DE', 'ru_RU']
+'locales' : ['en_US', 'es_ES', 'it_IT', 'zh_CN', 'id_ID', 'fr_FR', 'de_DE', 'ru_RU'],
 
-contact_sender = "PUT_SENDER_EMAIL_HERE"
-contact_recipient = "PUT_RECIPIENT_EMAIL_HERE"
+# contact page email settings
+'contact_sender' : "PUT_SENDER_EMAIL_HERE",
+'contact_recipient' : "PUT_RECIPIENT_EMAIL_HERE",
 
 # Password AES Encryption Parameters
-aes_key = "12_24_32_BYTES_KEY_FOR_PASSWORDS"
-salt = "_PUT_SALT_HERE_TO_SHA512_PASSWORDS_"
+'aes_key' : "12_24_32_BYTES_KEY_FOR_PASSWORDS",
+'salt' : "_PUT_SALT_HERE_TO_SHA512_PASSWORDS_",
 
 # get your own consumer key and consumer secret by registering at https://dev.twitter.com/apps
 # callback url must be: http://[YOUR DOMAIN]/login/twitter/complete
-twitter_consumer_key = 'PUT_YOUR_TWITTER_CONSUMER_KEY_HERE'
-twitter_consumer_secret = 'PUT_YOUR_TWITTER_CONSUMER_SECRET_HERE'
+'twitter_consumer_key' : 'PUT_YOUR_TWITTER_CONSUMER_KEY_HERE',
+'twitter_consumer_secret' : 'PUT_YOUR_TWITTER_CONSUMER_SECRET_HERE',
 
 #Facebook Login
 # get your own consumer key and consumer secret by registering at https://developers.facebook.com/apps
 #Very Important: set the site_url= your domain in the application settings in the facebook app settings page
 # callback url must be: http://[YOUR DOMAIN]/login/facebook/complete
-_FbApiKey = 'PUT_YOUR_FACEBOOK_PUBLIC_KEY_HERE'
-_FbSecret = 'PUT_YOUR_FACEBOOK_PUBLIC_KEY_HERE'
+'fb_api_key' : 'PUT_YOUR_FACEBOOK_PUBLIC_KEY_HERE',
+'fb_secret' : 'PUT_YOUR_FACEBOOK_PUBLIC_KEY_HERE',
 
 #Linkedin Login
 #Get you own api key and secret from https://www.linkedin.com/secure/developer
-linkedin_api = 'PUT_YOUR_LINKEDIN_PUBLIC_KEY_HERE'
-linkedin_secret = 'PUT_YOUR_LINKEDIN_PUBLIC_KEY_HERE'
+'linkedin_api' : 'PUT_YOUR_LINKEDIN_PUBLIC_KEY_HERE',
+'linkedin_secret' : 'PUT_YOUR_LINKEDIN_PUBLIC_KEY_HERE',
 
 # Github login
 # Register apps here: https://github.com/settings/applications/new
-github_server = 'github.com'
-github_redirect_uri = 'http://www.example.com/social_login/github/complete'
-github_client_id = 'PUT_YOUR_GITHUB_CLIENT_ID_HERE'
-github_client_secret = 'PUT_YOUR_GITHUB_CLIENT_SECRET_HERE'
+'github_server' : 'github.com',
+'github_redirect_uri' : 'http://www.example.com/social_login/github/complete',
+'github_client_id' : 'PUT_YOUR_GITHUB_CLIENT_ID_HERE',
+'github_client_secret' : 'PUT_YOUR_GITHUB_CLIENT_SECRET_HERE',
 
 # get your own recaptcha keys by registering at http://www.google.com/recaptcha/
-captcha_public_key = "PUT_YOUR_RECAPCHA_PUBLIC_KEY_HERE"
-captcha_private_key = "PUT_YOUR_RECAPCHA_PRIVATE_KEY_HERE"
+'captcha_public_key' : "PUT_YOUR_RECAPCHA_PUBLIC_KEY_HERE",
+'captcha_private_key' : "PUT_YOUR_RECAPCHA_PRIVATE_KEY_HERE",
 
 # Leave blank "google_analytics_domain" if you only want Analytics code
-google_analytics_domain = "YOUR_PRIMARY_DOMAIN (e.g. google.com)"
-google_analytics_code = "UA-XXXXX-X"
+'google_analytics_domain' : "YOUR_PRIMARY_DOMAIN (e.g. google.com)",
+'google_analytics_code' : "UA-XXXXX-X",
 
-error_templates = {
+'error_templates' : {
     403: 'errors/default_error.html',
     404: 'errors/default_error.html',
     500: 'errors/default_error.html',
-}
+},
 
 # Enable Federated login (OpenID and OAuth)
 # Google App Engine Settings must be set to Authentication Options: Federated Login
-enable_federated_login = True
+'enable_federated_login' : True,
 
 # jinja2 base layout templates
-base_layout = 'boilerplate_base.html'
+'base_layout' : 'boilerplate_base.html',
 
 # send error emails to developers
-send_mail_developer = True
+'send_mail_developer' : True,
 
 # fellas' list
-DEVELOPERS = (
+'developers' : (
     ('Santa Klauss', 'snowypal@northpole.com'),
-)
+),
+
+# ----> ADD MORE CONFIGURATION OPTIONS HERE <----
+
+} # end config

--- a/boilerplate/lib/test_helpers.py
+++ b/boilerplate/lib/test_helpers.py
@@ -7,8 +7,6 @@ import re
 from webapp2_extras import auth
 from boilerplate import config, models
 
-# globals
-cookie_name = config.webapp2_config['webapp2_extras.auth']['cookie_name']
 
 class HandlerHelpers():
 
@@ -144,6 +142,7 @@ class HandlerHelpers():
 
     def assert_user_logged_in(self, user_id=None):
         """Check if user is logged in."""
+        cookie_name = self.app.config.get('webapp2_extras.auth').get('cookie_name')
         self.assertIn(cookie_name, self.testapp.cookies,
                       'user is not logged in: session cookie not found')
         user = self.get_user_data_from_session()

--- a/boilerplate/lib/tests.py
+++ b/boilerplate/lib/tests.py
@@ -16,9 +16,13 @@ from google.appengine.ext import testbed
 
 from boilerplate import config
 from boilerplate.lib import i18n
+import webapp2
 
 class I18nTest(unittest.TestCase):    
     def setUp(self):
+        
+        # create a WSGI application.
+        self.app = webapp2.WSGIApplication(config=config.config)
         
         # activate GAE stubs
         self.testbed = testbed.Testbed()
@@ -35,12 +39,12 @@ class I18nTest(unittest.TestCase):
     def tearDown(self):
         self.testbed.deactivate()
         
-    def testDisableI18n(self):
-        config.locales = []
-        locale = i18n.set_locale(None)
+    def test_disable_i18n(self):
+        self.app.config['locales'] = []
+        locale = i18n.set_locale(self)
         self.assertEqual(locale, None)
-        config.locales = None 
-        locale = i18n.set_locale(None)
+        self.app.config['locales'] = None 
+        locale = i18n.set_locale(self)
         self.assertEqual(locale, None)
         
 

--- a/boilerplate/lib/twitter.py
+++ b/boilerplate/lib/twitter.py
@@ -1,8 +1,8 @@
-from boilerplate import config
 from boilerplate.lib.oauth2 import Consumer as OAuthConsumer, Token, Request as OAuthRequest, \
                    SignatureMethod_HMAC_SHA1
 import urllib2
 import json
+import webapp2
 
 # Twitter configuration
 TWITTER_SERVER = 'api.twitter.com'
@@ -116,4 +116,6 @@ class TwitterAuth(object):
         """Return tuple with Consumer Key and Consumer Secret for current
         service provider. Must return (key, secret), order *must* be respected.
         """
-        return config.twitter_consumer_key, config.twitter_consumer_secret
+        app = webapp2.get_app()
+        
+        return app.config.get('twitter_consumer_key'), app.config.get('twitter_consumer_secret')

--- a/boilerplate/lib/utils.py
+++ b/boilerplate/lib/utils.py
@@ -7,8 +7,7 @@ import string
 import unicodedata
 from datetime import datetime, timedelta
 import Cookie
-
-from boilerplate import config
+import webapp2
 
 def random_string(size=6, chars=string.ascii_letters + string.digits):
     """ Generate random string """
@@ -16,6 +15,7 @@ def random_string(size=6, chars=string.ascii_letters + string.digits):
 
 def hashing(plaintext, salt=""):
     """ Returns the hashed and encrypted hexdigest of a plaintext and salt"""
+    app = webapp2.get_app()
 
     # Hashing (sha512)
     plaintext = "%s@%s" % (plaintext, salt)
@@ -31,7 +31,7 @@ def hashing(plaintext, salt=""):
         # a priori the hash to match. We take 16 bytes from the hexdigest to make the vectors different for each hashed
         # plaintext.
         iv = phrase_digest[:16]
-        encryptor = AES.new(config.aes_key, mode,iv)
+        encryptor = AES.new(app.config.get('aes_key'), mode,iv)
         ciphertext = [encryptor.encrypt(chunk) for chunk in chunks(phrase_digest, 16)]
         return ''.join(ciphertext)
     except ImportError, e:

--- a/main.py
+++ b/main.py
@@ -27,13 +27,13 @@ from boilerplate import routes as boilerplate_routes
 from boilerplate import config
 from boilerplate.lib.basehandler import handle_error
 
-app = webapp2.WSGIApplication(debug = os.environ['SERVER_SOFTWARE'].startswith('Dev'), config=config.webapp2_config)
+app = webapp2.WSGIApplication(debug = os.environ['SERVER_SOFTWARE'].startswith('Dev'), config=config.config)
 
 app.error_handlers[403] = handle_error
 app.error_handlers[404] = handle_error
 if not app.debug:
     app.error_handlers[500]    = handle_error
-    config.send_mail_developer = False
+    app.config['send_mail_developer'] = False
 
 routes.add_routes(app)
 boilerplate_routes.add_routes(app)


### PR DESCRIPTION
Config updated to include all configuration parameters in the webapp2
config dict.  config is no longer imported (except in main.py and
unittest setup), instead it is retrieved from app.config.

This is best practice according to webapp2 docs and will allow us to
have multiple app instances with different configurations, let us
override settings in unittests more easily, and let us have a user
config which overrides the boilerplate config without breaking
boilerplate unittests.

Note that config params are retrieved using dict.get() syntax which does
not throw errors if the config param requested does not exist.  If this
is undesirable we can change to config[] syntax.
