### PR TITLE
changes to make kickstarting a new application easy

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,13 @@ Get started in just a few easy steps
 1. Download the code of this Boilerplate ([here](https://github.com/coto/gae-boilerplate/zipball/master))
 1. Run locally ([instructions](https://developers.google.com/appengine/docs/python/tools/devserver)).
 1. Set your 'application' name in [app.yaml](https://github.com/coto/gae-boilerplate/blob/master/app.yaml)
-1. Set parameters in [config.py](https://github.com/coto/gae-boilerplate/blob/master/boilerplate/config.py).  (secret key, [recaptcha code](http://www.google.com/recaptcha/whyrecaptcha), salt etc.)
+1. Set custom config parameters in [config.py](https://github.com/coto/gae-boilerplate/blob/master/config.py).  (secret key, [recaptcha code](http://www.google.com/recaptcha/whyrecaptcha), salt etc.)  To get started, copy the default settings from [boilerplate/config.py](https://github.com/coto/gae-boilerplate/blob/master/boilerplate/config.py).  Note that most of the default settings will need to be changed to yield a secure and working application.  Make the changes to these settings in the root config.py.  The root config.py takes precedence over the boilerplate config.py.
 1. Set Authentication Options dropdown to Federated Login in the Google App Engine control panel (or if you do not want federated login, set enable_federated_login to false in config.py)
 1. Deploy it online ([instructions](https://developers.google.com/appengine/docs/python/gettingstarted/uploading) - recommended setup: python 2.7, high replication datastore)
 
+Please note that boilerplate code is located in the boilerplate module while your custom application code should be located in the web module.
+The intention is that separating the boilerplate code from your application code will avoid merge conflicts as you keep up with future boilerplate changes.
+Settings, code, and templates in the root [config.py](https://github.com/coto/gae-boilerplate/blob/master/config.py), web module, and templates directory take precedence over the equivalent files in the boilerplate module.
 
 Functions and features:
 -----------------------
@@ -53,7 +56,7 @@ Open Source
 -----------
 If you want to add, fix or improve something, create an [issue](https://github.com/coto/gae-boilerplate/issues) or send a [Pull Request](https://github.com/coto/gae-boilerplate/pull/new/master).
 
-Before committing fixes we recommend running the unitests.  This will help guard against changes that accidently break other code.  See the testing section below for instructions.
+Before committing fixes we recommend running the unitests (in the boilerplate package).  This will help guard against changes that accidently break other code.  See the testing section below for instructions.
 
 Feel free to commit improvements or new features. Feedback, comments and ideas are welcome.
 
@@ -61,7 +64,8 @@ Testing
 -------
 **Unit testing**
 + Unit tests can be run via [testrunner](https://github.com/coto/gae-boilerplate/blob/master/testrunner.py) or in Eclipse by right clicking on the web folder and selecting run as... Python unit-test.
-+ Please add or modify the [unittests](https://github.com/coto/gae-boilerplate/tree/master/web/tests) as necessary.
++ You may need to add /boilerplate/external to your python path.
++ Please add unittests for your application to [unittests](https://github.com/coto/gae-boilerplate/tree/master/web/tests).
 + To run unittests it may be necessary to install [webtest](http://webtest.pythonpaste.org/en/latest/index.html#installation), [mock](http://www.voidspace.org.uk/python/mock/), and [pyquery](http://packages.python.org/pyquery/) in your local python installation.
 + Your own unittests can be created similarly to those in the boilerplate.  Inheriting from boilerplate.lib.test_helpers.HandlerHelpers will provide access to convenient handler testing methods used by the boilerplate.
 

--- a/boilerplate/config.py
+++ b/boilerplate/config.py
@@ -1,3 +1,8 @@
+"""
+This is the boilerplate default configuration file.
+Changes and additions to settings should be done in config.py
+located in the application root rather than this config.
+"""
 config = {
 
 # webapp2 sessions
@@ -76,7 +81,7 @@ config = {
 # Google App Engine Settings must be set to Authentication Options: Federated Login
 'enable_federated_login' : True,
 
-# jinja2 base layout templates
+# jinja2 base layout template
 'base_layout' : 'boilerplate_base.html',
 
 # send error emails to developers

--- a/boilerplate/tests.py
+++ b/boilerplate/tests.py
@@ -50,7 +50,7 @@ class AppTest(unittest.TestCase, test_helpers.HandlerHelpers):
         self.testapp = webtest.TestApp(self.app, extra_environ={'REMOTE_ADDR' : '127.0.0.1'})
         
         # use absolute path for templates
-        self.app.config['webapp2_extras.jinja2']['template_path'] =  os.path.join(os.path.join(os.path.dirname(boilerplate.__file__), 'templates'))
+        self.app.config['webapp2_extras.jinja2']['template_path'] =  os.path.join(os.path.dirname(boilerplate.__file__), 'templates')
 
         # activate GAE stubs
         self.testbed = testbed.Testbed()

--- a/config.py
+++ b/config.py
@@ -1,0 +1,9 @@
+"""
+This configuration file should contain all custom config settings for the application.
+It takes precedence over the config located in the boilerplate package.
+"""
+config = {
+
+# ----> ADD MORE CONFIGURATION OPTIONS HERE <----
+
+} # end config

--- a/main.py
+++ b/main.py
@@ -24,10 +24,14 @@ import webapp2
 
 import routes
 from boilerplate import routes as boilerplate_routes
-from boilerplate import config
+from boilerplate import config as boilerplate_config
+import config
 from boilerplate.lib.basehandler import handle_error
 
-app = webapp2.WSGIApplication(debug = os.environ['SERVER_SOFTWARE'].startswith('Dev'), config=config.config)
+webapp2_config = boilerplate_config.config
+webapp2_config.update(config.config)
+
+app = webapp2.WSGIApplication(debug = os.environ['SERVER_SOFTWARE'].startswith('Dev'), config=webapp2_config)
 
 app.error_handlers[403] = handle_error
 app.error_handlers[404] = handle_error

--- a/web/tests.py
+++ b/web/tests.py
@@ -1,0 +1,98 @@
+'''
+Run the tests using testrunner.py script in the project root directory.
+
+Usage: testrunner.py SDK_PATH TEST_PATH
+Run unit tests for App Engine apps.
+
+SDK_PATH    Path to the SDK installation
+TEST_PATH   Path to package containing test modules
+
+Options:
+  -h, --help  show this help message and exit
+
+'''
+import unittest
+import webapp2
+import os
+import webtest
+from google.appengine.ext import testbed
+
+from mock import Mock
+from mock import patch
+
+import boilerplate
+from boilerplate import models
+from boilerplate import config as boilerplate_config
+import config
+from boilerplate import routes
+from boilerplate import routes as boilerplate_routes
+from boilerplate.lib import utils
+from boilerplate.lib import captcha
+from boilerplate.lib import i18n
+from boilerplate.lib import test_helpers
+
+# setting HTTP_HOST in extra_environ parameter for TestApp is not enough for taskqueue stub
+os.environ['HTTP_HOST'] = 'localhost'
+
+# globals
+network = False
+
+# mock Internet calls
+if not network:
+    i18n.get_territory_from_ip = Mock(return_value=None)
+
+
+class AppTest(unittest.TestCase, test_helpers.HandlerHelpers):
+    def setUp(self):
+
+        # create a WSGI application.
+        webapp2_config = boilerplate_config.config
+        webapp2_config.update(config.config)
+        self.app = webapp2.WSGIApplication(config=webapp2_config)
+        routes.add_routes(self.app)
+        boilerplate_routes.add_routes(self.app)
+        self.testapp = webtest.TestApp(self.app, extra_environ={'REMOTE_ADDR' : '127.0.0.1'})
+        
+        # use absolute path for templates
+        self.app.config['webapp2_extras.jinja2']['template_path'] =  [os.path.join(os.path.dirname(boilerplate.__file__), '../templates'), os.path.join(os.path.dirname(boilerplate.__file__), 'templates')]
+
+        # activate GAE stubs
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_datastore_v3_stub()
+        self.testbed.init_memcache_stub()
+        self.testbed.init_urlfetch_stub()
+        self.testbed.init_taskqueue_stub()
+        self.testbed.init_mail_stub()
+        self.mail_stub = self.testbed.get_stub(testbed.MAIL_SERVICE_NAME)
+        self.taskqueue_stub = self.testbed.get_stub(testbed.TASKQUEUE_SERVICE_NAME)
+        self.testbed.init_user_stub()
+
+        self.headers = {'User-Agent' : 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_4) Version/6.0 Safari/536.25',
+                        'Accept-Language' : 'en_US'}
+
+        # fix configuration if this is still a raw boilerplate code - required by test with mails
+        if not utils.is_email_valid(self.app.config.get('contact_sender')):
+            self.app.config['contact_sender'] = "noreply-testapp@example.com"
+        if not utils.is_email_valid(self.app.config.get('contact_recipient')):
+            self.app.config['contact_recipient'] = "support-testapp@example.com"
+
+    def tearDown(self):
+        self.testbed.deactivate()
+
+
+class ModelTest(unittest.TestCase):
+    def setUp(self):
+
+        # activate GAE stubs
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_datastore_v3_stub()
+        self.testbed.init_memcache_stub()
+
+    def tearDown(self):
+        self.testbed.deactivate()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
New config.py and tests.py in the root and web modules respectively to
make kickstarting a new application easy while keeping the boilerplate
default config and tests separate for easy future udpates. 
Documentation and comments updated.  Root config and templates take
precedence over boilerplate config and templates.
