### PR TITLE
remove references to user config added from #182

### DIFF
--- a/boilerplate/lib/basehandler.py
+++ b/boilerplate/lib/basehandler.py
@@ -13,7 +13,6 @@ from google.appengine.api import taskqueue
 # local application/library specific imports
 from boilerplate import models
 from boilerplate.lib import utils, i18n
-import config
 from babel import Locale
 
 def user_required(handler):

--- a/boilerplate/lib/test_helpers.py
+++ b/boilerplate/lib/test_helpers.py
@@ -6,7 +6,6 @@ import webapp2
 import re
 from webapp2_extras import auth
 from boilerplate import models
-import config
 
 
 class HandlerHelpers():

--- a/boilerplate/lib/tests.py
+++ b/boilerplate/lib/tests.py
@@ -16,7 +16,6 @@ from google.appengine.ext import testbed
 import webapp2
 
 
-import config
 from boilerplate import base_config as boilerplate_config
 from boilerplate.lib import i18n
 
@@ -24,7 +23,6 @@ class I18nTest(unittest.TestCase):
     def setUp(self):
 
         webapp2_config = boilerplate_config.config
-        webapp2_config.update(config.config)
 
         # create a WSGI application.
         self.app = webapp2.WSGIApplication(config=webapp2_config)

--- a/boilerplate/tests.py
+++ b/boilerplate/tests.py
@@ -30,8 +30,6 @@ from boilerplate.lib import captcha
 from boilerplate.lib import i18n
 from boilerplate.lib import test_helpers
 
-import config
-
 # setting HTTP_HOST in extra_environ parameter for TestApp is not enough for taskqueue stub
 os.environ['HTTP_HOST'] = 'localhost'
 
@@ -47,7 +45,6 @@ class AppTest(unittest.TestCase, test_helpers.HandlerHelpers):
     def setUp(self):
 
         webapp2_config = boilerplate_config.config
-        webapp2_config.update(config.config)
 
         # create a WSGI application.
         self.app = webapp2.WSGIApplication(config=webapp2_config)


### PR DESCRIPTION
remove references to user config added from #182.  The boilerplate
section of code should not reference application specific config
directly via imports, rather it should reference it via the request
object in handlers and the app object elsewhere as is done in the code. 
This ensures it will have the current config settings of the application
regardless of where they were loaded or how they have been manipulated. 
Additionally boilerplate unittests should not have user configs merging
into boilerplate configs or they will fail when users create custom
configs.  boilerplate tests should run under the assumption that they
are testing the boilerplate as it has been designed by the open source
project while user tests in the web package should test any changes made
by the specific application built by the user.

Please let me know if you have any disagreement.
