### PR TITLE
Fixing unicode issues with hmac.py on LinkedIn association

### DIFF
--- a/boilerplate/external/linkedin/linkedin.py
+++ b/boilerplate/external/linkedin/linkedin.py
@@ -779,6 +779,8 @@ class LinkedIn(object):
         return key
 
     def _calc_signature(self, url, query_dict, token_secret, method = "GET", update=True):
+        if token_secret != None:
+            token_secret = token_secret.encode('ascii')
         query_string = self._quote(self._urlencode(query_dict))
         signature_base_string = "&".join([self._quote(method), self._quote(url), query_string])
         hashed = hmac.new(self._calc_key(token_secret), signature_base_string, sha)


### PR DESCRIPTION
Error was:
  File "C:\Python27\lib\hmac.py", line 72, in **init**
    self.outer.update(key.translate(trans_5C))
TypeError: character mapping must return integer, None or unicode

This was attributed to obtaining a unicode token_secret and trying to pass it into hmac.new() on line 786 of linkedin.py.

See HMAC's lack of utf-8 support explained here:
http://www.terminally-incoherent.com/blog/2010/05/06/character-mapping-m
ust-return-integer-none-or-unicode/
