### PR TITLE
Fix registration problem

### DIFF
--- a/boilerplate/handlers.py
+++ b/boilerplate/handlers.py
@@ -774,7 +774,7 @@ class RegisterHandler(RegisterBaseHandler):
             # User registered successfully
             # But if the user registered using the form, the user has to check their email to activate the account ???
             try:
-                user_info = models.User.get_by_email(email)
+                user_info = user[1]
                 if (user_info.activated == False):
                     # send email
                     subject =  _("%s Account Verification" % self.app.config.get('app_name'))


### PR DESCRIPTION
In the current version when I run on localhost and try to create a user, the web page says unexpected error and the console log says:
ERROR    2013-06-20 19:09:14,516 handlers.py:852] Unexpected error creating the user g: 'NoneType' object has no attribute 'activated'

This implements the fix described by alexsms on
https://github.com/coto/gae-boilerplate/issues/236#issuecomment-16306657

All unit tests pass
