### PR TITLE
fix tests failing due to config and environment problems

### DIFF
--- a/boilerplate/lib/decorators.py
+++ b/boilerplate/lib/decorators.py
@@ -5,7 +5,7 @@ import logging
 # related third party imports
 from google.appengine.api import users
 # local application/library specific imports
-import config
+from config import config
 
 
 def user_required(handler):
@@ -55,7 +55,7 @@ def admin_required(handler):
         """
             If handler has no login_url specified invoke a 403 error
         """
-        if not users.is_current_user_admin() and config.environment != "localhost":
+        if not users.is_current_user_admin() and config.get('environment') == "production":
             self.response.write(
                 '<div style="padding-top: 200px; height:178px; width: 500px; color: white; margin: 0 auto; font-size: 52px; text-align: center; background: url(\'http://3.bp.blogspot.com/_d_q1e2dFExM/TNWbWrJJ7xI/AAAAAAAAAjU/JnjBiTSA1xg/s1600/Bank+Vault.jpg\')">Forbidden Access <a style=\'color: white;\' href=\'%s\'>Login</a></div>' %
                 users.create_login_url(self.request.path_url + self.request.query_string))
@@ -77,7 +77,7 @@ def cron_method(handler):
          Allow run in localhost calling the url
         """
         if self.request.headers.get('X-AppEngine-Cron') is None \
-            and config.environment != "localhost" \
+            and config.get('environment') == "production" \
             and not users.is_current_user_admin():
             return self.error(403)
         else:
@@ -97,7 +97,7 @@ def taskqueue_method(handler):
          Allow run in localhost calling the url
         """
         if self.request.headers.get('X-AppEngine-TaskName') is None \
-            and config.environment != "localhost" \
+            and config.get('environment') == "production" \
             and not users.is_current_user_admin():
             return self.error(403)
         else:

--- a/boilerplate/tests.py
+++ b/boilerplate/tests.py
@@ -51,7 +51,7 @@ class AppTest(unittest.TestCase, test_helpers.HandlerHelpers):
         routes.add_routes(self.app)
         boilerplate_routes.add_routes(self.app)
         self.testapp = webtest.TestApp(self.app, extra_environ={'REMOTE_ADDR' : '127.0.0.1'})
-        
+
         # activate GAE stubs
         self.testbed = testbed.Testbed()
         self.testbed.activate()
@@ -82,7 +82,7 @@ class AppTest(unittest.TestCase, test_helpers.HandlerHelpers):
 
     def test_homepage_has_no_calls_create_login_url(self):
         with patch('google.appengine.api.users.create_login_url') as create_login_url:
-            self.get('/')            
+            self.get('/')
         self.assertEqual(0, create_login_url.call_count)
 
     def test_csrf_protection(self):
@@ -116,14 +116,14 @@ class AppTest(unittest.TestCase, test_helpers.HandlerHelpers):
         form['password'] = '123456'
         self.submit(form, expect_error=True, error_message='Please check your email to activate it')
         self.assert_user_not_logged_in()
-        
+
     def _login_openid(self, provider, uid, email=None):
         openid_user = Mock()
         openid_user.federated_identity.return_value = uid
         openid_user.email.return_value = email
         with patch('google.appengine.api.users.get_current_user', return_value=openid_user):
             response = self.get('/social_login/{}/complete'.format(provider), status=302)
-            response = response.follow(status=200, headers=self.headers) 
+            response = response.follow(status=200, headers=self.headers)
         return response
 
     def test_login_openid_add_association(self):
@@ -148,7 +148,7 @@ class AppTest(unittest.TestCase, test_helpers.HandlerHelpers):
         response = self._test_login_twitter()
         self.assert_success_message_in_response(response, "Welcome!  You have been registered as a new user")
         self.assert_user_logged_in()
- 
+
     def test_login_twitter_add_association(self):
         self.register_activate_login_testuser()
         response = self._test_login_twitter()
@@ -159,7 +159,7 @@ class AppTest(unittest.TestCase, test_helpers.HandlerHelpers):
         models.SocialUser(user=user.key, provider='twitter', uid='7588892').put()
         self._test_login_twitter()
         self.assert_user_logged_in()
- 
+
     def _test_login_twitter(self):
         oauth_token = 'NPcudxy0yU5T3tBzho7iCotZ3cnetKwcTIRlX0iwRl0'
         oauth_token_secret = 'veNRnAWe6inFuo8o2u8SLLZLjolYDmDP7SzL0YfYI'
@@ -194,10 +194,10 @@ class AppTest(unittest.TestCase, test_helpers.HandlerHelpers):
             self.assertEquals(urlopen.call_count, 2)
             self.assertTrue(urlopen.call_args_list[1][0][0].
                             startswith('https://api.twitter.com/oauth/access_token?'))
- 
+
             response = response.follow(status=200, headers=self.headers)
             return response
- 
+
     def test_resend_activation_mail(self):
         self.register_testuser()
 
@@ -339,11 +339,11 @@ class AppTest(unittest.TestCase, test_helpers.HandlerHelpers):
 
     def test_register(self):
         self._test_register('/register/',
-                    expect_fields=['username', 'name', 'last_name', 'email', 'password', 'c_password', 'country'])
+                    expect_fields=['username', 'name', 'last_name', 'email', 'password', 'c_password', 'country', 'tz'])
 
     def test_register_from_home_page(self):
         self._test_register('/',
-                    expect_fields=['username', 'email', 'country', 'password', 'c_password'])
+                    expect_fields=['username', 'email', 'country', 'password', 'c_password', 'tz'])
 
     def _test_register(self, url, form_id='form_register', expect_fields=None):
         form = self.get_form(url, form_id, expect_fields=expect_fields)

--- a/config/testing.py
+++ b/config/testing.py
@@ -1,7 +1,7 @@
 config = {
 
 # environment this app is running on: localhost, testing, production
-'environment': "localhost",
+'environment': "testing",
 
 # ----> ADD MORE CONFIGURATION OPTIONS HERE <----
 


### PR DESCRIPTION
My first contribution so go easy on me, and review carefully :)

Changed config import for decorators to go straight to the config hash.

Decorators that care about environments now run only in production (rather than non-localhost) - I don't fully understand why these don't work / shouldn't run in localhost/testing so please check that I've not made an incorrect assumption.

The environment in the test config is now 'testing'.

Also fixed some tests who's assertions needed to change due to an old commit:
https://github.com/coto/gae-boilerplate/commit/94a068eb31edc9280384f77b054f26a7e1551d22
