### PR TITLE
Theme based static files

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -68,9 +68,10 @@ handlers:
   static_files: bp_includes/static/img/\1
   upload: bp_includes/static/img/(.*\.(gif|png|jpg))
 
-- url: /css/
+- url: /(\w*)/css/(.*\.css)$
   mime_type: text/css
-  static_dir: bp_content/themes/default/static/css
+  static_files: bp_content/themes/\1/static/css/\2
+  upload: bp_content/themes/(\w*)/static/css/(.*\.css)$
 
 - url: /fonts/(.*\.eot)
   mime_type: application/vnd.ms-fontobject
@@ -82,9 +83,10 @@ handlers:
   static_files: bp_content/themes/default/static/fonts/\1
   upload: bp_content/themes/default/static/fonts/(.*\.otf)
 
-- url: /js
+- url: /(\w*)/js/(.*\.js)$
   mime_type: text/javascript
-  static_dir: bp_content/themes/default/static/js
+  static_files: bp_content/themes/\1/static/js/\2
+  upload: bp_content/themes/(\w*)/static/js/(.*\.js)$
 
 - url: /img/(\w*)/(.*\.(gif|png|jpg|jpeg))
   static_files: bp_content/themes/\1/static/img/\2

--- a/bp_content/themes/default/templates/base.html
+++ b/bp_content/themes/default/templates/base.html
@@ -20,7 +20,7 @@
         <link rel="apple-touch-icon" href="/{{ theme }}/apple-touch-icon.png">
     {% endif %}
     <link rel="stylesheet" href="/boilerplate/css/boilerplate.min.css">
-    <link rel="stylesheet" href="/css/style.css">
+    <link rel="stylesheet" href="/{{ theme }}/css/style.css">
     {% block mediaCSS %}{% endblock %}
 
     {{ google_analytics_code }}
@@ -203,7 +203,7 @@
 <!-- scripts concatenated and minified via build script -->
 <script src="/boilerplate/js/plugins.js"></script>
 <script src="/boilerplate/js/script.js"></script>
-<script src="/js/script.js"></script>
+<script src="/{{ theme }}/js/script.js"></script>
 {% if locale_language_id != "en" %}
     {% if locale_iso.language == "pt" and locale_iso.territory == "BR" %}
         <script src="/boilerplate/js/libs/jquery_validation/localization/messages_{{ locale_iso.language }}_{{ locale_iso.territory }}.js"></script>


### PR DESCRIPTION
This pull request is intended to avoid changing `static_dir`/`static_files` configurations in `app.yaml` when creating _theme_ based `js` and `css` files.

Should the default **gae-boilerplate** error pages (`over_quota.html`, `dos_api_denial.html` and `timeout.html`) be at _includes_ level rather than _theme_ level?
