### PR TITLE
[https://github.com/coto/gae-boilerplate/issues/279] Make bp_includes.lib.basehandler share jinja2_factory with bp_includes.lib.error_handler.

### DIFF
--- a/bp_includes/lib/basehandler.py
+++ b/bp_includes/lib/basehandler.py
@@ -12,35 +12,8 @@ from webapp2_extras import auth
 from webapp2_extras import sessions
 # local application/library specific imports
 from bp_includes import models
-from bp_includes.lib import utils, i18n
+from bp_includes.lib import utils, i18n, jinja_bootstrap
 from babel import Locale
-
-
-def generate_csrf_token():
-    session = sessions.get_store().get_session()
-    if '_csrf_token' not in session:
-        session['_csrf_token'] = utils.random_string()
-    return session['_csrf_token']
-
-
-def jinja2_factory(app):
-    j = jinja2.Jinja2(app)
-    j.environment.filters.update({
-        # Set filters.
-        # ...
-    })
-    j.environment.globals.update({
-        # Set global variables.
-        'csrf_token': generate_csrf_token,
-        'uri_for': webapp2.uri_for,
-        'getattr': getattr,
-    })
-    j.environment.tests.update({
-        # Set test.
-        # ...
-    })
-    return j
-
 
 class ViewClass:
     """
@@ -267,7 +240,7 @@ class BaseHandler(webapp2.RequestHandler):
 
     @webapp2.cached_property
     def jinja2(self):
-        return jinja2.get_jinja2(factory=jinja2_factory, app=self.app)
+        return jinja2.get_jinja2(factory=jinja_bootstrap.jinja2_factory, app=self.app)
 
     @webapp2.cached_property
     def get_base_layout(self):

--- a/bp_includes/lib/error_handler.py
+++ b/bp_includes/lib/error_handler.py
@@ -12,6 +12,7 @@ from webapp2_extras import jinja2
 from google.appengine.api import app_identity
 from google.appengine.api import taskqueue
 # local application/library specific imports
+from bp_includes.lib import jinja_bootstrap
 import i18n
 
 
@@ -78,7 +79,7 @@ def handle_error(request, response, exception):
 
     status_int = hasattr(exception, 'status_int') and exception.status_int or 500
     template = request.app.config.get('error_templates')[status_int]
-    t = jinja2.get_jinja2(app=webapp2.get_app()).render_template(template, **c)
+    t = jinja2.get_jinja2(factory=jinja_bootstrap.jinja2_factory, app=webapp2.get_app()).render_template(template, **c)
     logging.error("Error {}: {}".format(status_int, exception))
     response.write(t)
     response.set_status(status_int)

--- a/bp_includes/lib/jinja_bootstrap.py
+++ b/bp_includes/lib/jinja_bootstrap.py
@@ -1,0 +1,28 @@
+import webapp2
+from webapp2_extras import jinja2
+from webapp2_extras import sessions
+from bp_includes.lib import utils
+
+def generate_csrf_token():
+    session = sessions.get_store().get_session()
+    if '_csrf_token' not in session:
+        session['_csrf_token'] = utils.random_string()
+    return session['_csrf_token']
+
+def jinja2_factory(app):
+    j = jinja2.Jinja2(app)
+    j.environment.filters.update({
+        # Set filters.
+        # ...
+    })
+    j.environment.globals.update({
+        # Set global variables.
+        'csrf_token': generate_csrf_token,
+        'uri_for': webapp2.uri_for,
+        'getattr': getattr,
+    })
+    j.environment.tests.update({
+        # Set test.
+        # ...
+    })
+    return j


### PR DESCRIPTION
Issue 279 is happening because error_handler (bp_includes/lib) is not initializing Jinja with the factory function provided by basehandler (called jinja2_factory). I split out generate_csrf_token and jinja2_factory from basehandler into a separate module, included it in both basehandler and error_handler, and that fixes the abovementioned behavior on our site.

Unit tests all succeed with the change.

Please let me know if you need any additional information or confirmation. Many thanks for creating the boilerplate project; it has been very useful.
