### PR TITLE
To make this code work with angularjs ajax post requests

### DIFF
--- a/bp_includes/lib/basehandler.py
+++ b/bp_includes/lib/basehandler.py
@@ -55,7 +55,8 @@ class BaseHandler(webapp2.RequestHandler):
             # csrf protection
             if self.request.method == "POST" and not self.request.path.startswith('/taskqueue'):
                 token = self.session.get('_csrf_token')
-                if not token or token != self.request.get('_csrf_token'):
+                if not token or (token != self.request.get('_csrf_token') and
+                         token != self.request.headers.get('_csrf_token')):
                     self.abort(403)
 
             # Dispatch the request.


### PR DESCRIPTION
Using boilerplate with angularjs i noticed that angular sets the csrf token in ajax post requests as a request header and not in the request body.  This change caters to that
