### PR TITLE
Legacy note on top and removed other legacy projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
+> **ATTENTION**: This project is **legacy** and uses older tech stack used by Google App Engine, like [webapp2](https://webapp2.readthedocs.io/en/latest/) and Datastore. Nowadays (mid 2016) it is recommedable to use more moderm technologies like [Flask](http://flask.pocoo.org/), [NDB](https://cloud.google.com/appengine/docs/python/ndb/), [Cloud SQL](https://cloud.google.com/sql/docs/) and many more. **Thanks everybody for their contributions**.
+
+> ### Try [gae-init](https://github.com/gae-init/gae-init) — an up-to-date Flask boilerplate.
+
+-----------------------
+
 [Google App Engine Boilerplate Legacy](http://appengine.beecoss.com) [![Build Status](https://secure.travis-ci.org/coto/gae-boilerplate.png)](http://travis-ci.org/coto/gae-boilerplate)
 ==============================
 
-This Project was Sponsored by <a href="http://www.jetbrains.com/pycharm/" alt="Download PyCharm">
-  PyCharm
-</a>
-
-**NOTE**: This Project is Legacy and uses the first technology used by Google App Engine, like webapp2 as Python Framework and DataStore as Data Base. Nowadays (mid 2016) it is recommedable to use more moderm technology like Flask as Framework, MySQL as databasete and many more new technologies. Thanks everybody for their contributions.
+This Project was Sponsored by [PyCharm](http://www.jetbrains.com/pycharm/)
 
 Google App Engine Boilerplate gets your project off the ground quickly using the Google App Engine platform. 
 Create powerful applications by using the latest technology supported on Google App Engine. 
@@ -244,8 +246,3 @@ these [amazing people](https://github.com/coto/gae-boilerplate/graphs/contributo
 + [f1shear](https://github.com/f1shear)
 + [presveva](https://github.com/presveva)
 + [Sorced-Jim](https://github.com/sorced-Jim)
-
-**Flask Boilerplates**
-+ [gae-init](https://github.com/gae-init/gae-init)
-+ [flask-boilerplate](https://github.com/mjhea0/flask-boilerplate) **Heroku**
-+ [flask-appengine-template](https://github.com/kamalgill/flask-appengine-template)


### PR DESCRIPTION
Made it more clear for the newcomers that this project is unfortunately legacy.

Also `flask-boilerplate` and `flask-appengine-template` more or less share the same destiny, as you can see it from the latest commits:
- https://github.com/mjhea0/flask-boilerplate/commits/master
- https://github.com/kamalgill/flask-appengine-template/commits/master

I added `gae-init` in a more prominent spot as this project is pretty much [up-to-date](https://github.com/gae-init/gae-init/releases), comes in different [flavours](https://github.com/gae-init) as separete projects, with [documentation](http://docs.gae-init.appspot.com/) and [very active](https://github.com/gae-init/gae-init/commits/master). 

Lastly you can see that the project is being used all around the world and there is no plan to stop the support in the future :)
- https://gae-init.appspot.com/stats/
- https://gae-init.appspot.com/stats/month/
